### PR TITLE
Correct the bitfields for RETW instruction

### DIFF
--- a/data/languages/xtensaTodo.sinc
+++ b/data/languages/xtensaTodo.sinc
@@ -116,7 +116,7 @@
 :movsp at, as is op2 = 0 & op1 = 0 & ar = 0b0001 & as & at & op0 = 0 unimpl
 
 # RETW - Windowed Return, pg. 480.
-:retw is op2 = 0 & ar = 0 & as = 0 & at = 0 & u2_18.19 = 0b10 & u2_16.17 = 0b01 & op0 = 0 {
+:retw is op2 = 0 & ar = 0 & as = 0 & at = 0 & u2_6.7 = 0b10 & u2_4.5 = 0b01 & op0 = 0 {
     return [a0];
 }
 

--- a/data/languages/xtensaTodo.sinc
+++ b/data/languages/xtensaTodo.sinc
@@ -116,7 +116,7 @@
 :movsp at, as is op2 = 0 & op1 = 0 & ar = 0b0001 & as & at & op0 = 0 unimpl
 
 # RETW - Windowed Return, pg. 480.
-:retw is op2 = 0 & ar = 0 & as = 0 & at = 0 & u2_6.7 = 0b10 & u2_4.5 = 0b01 & op0 = 0 {
+:retw is op2 = 0 & op1 = 0 & ar = 0 & as = 0 & u2_6.7 = 0b10 & u2_4.5 = 0b01 & op0 = 0 {
     return [a0];
 }
 


### PR DESCRIPTION
Per the manual, the RETW instruction should use bits 4-5 and 6-7, not 16-17 and 18-19.