### PR TITLE
Fix issue with Ghidra 10.x (tested with Ghidra 10.2.2)

### DIFF
--- a/data/languages/xtensa.cspec
+++ b/data/languages/xtensa.cspec
@@ -53,7 +53,7 @@
       </input>
       <output>
         <pentry minsize="1" maxsize="4" extension="inttype">
-          <register name="o2"/>
+          <register name="a2"/>
         </pentry>
         <pentry minsize="5" maxsize="8" extension="inttype">
           <addr space="join" piece1="a3" piece2="a2"/>


### PR DESCRIPTION
Issue with actual ghidra-xtensa https://github.com/Ebiroll/ghidra-xtensa/commit/e83913719d68338569c66c5ef2e3ae9c96c0226b
Build OK even with Ghidra 10.2.2
Error when using Xtensa on a elf... with Ghidra 10.2.2
Exception reading Xtensa:LE:32:default/default(xtensa.cspec): <pentry> join must overlap at least one previous entry
ghidra.program.model.lang.CompilerSpecNotFoundException: Exception reading Xtensa:LE:32:default/default(xtensa.cspec): <pentry> join must overlap at least one previous entry
	at ghidra.program.model.lang.BasicCompilerSpec.<init>(BasicCompilerSpec.java:153)
	at ghidra.app.plugin.processors.sleigh.SleighLanguage.getCompilerSpecByID(SleighLanguage.java:1148)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.doLoad(AbstractLibrarySupportLoader.java:708)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.loadProgram(AbstractLibrarySupportLoader.java:98)
	at ghidra.app.util.opinion.AbstractProgramLoader.load(AbstractProgramLoader.java:126)
	at ghidra.plugin.importer.ImporterUtilities.importSingleFile(ImporterUtilities.java:368)
	at ghidra.plugin.importer.ImporterDialog.lambda$okCallback$7(ImporterDialog.java:351)
	at ghidra.util.task.TaskBuilder$TaskBuilderTask.run(TaskBuilder.java:306)
	at ghidra.util.task.Task.monitoredRun(Task.java:134)
	at ghidra.util.task.TaskRunner.lambda$startTaskThread$0(TaskRunner.java:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: ghidra.xml.XmlParseException: <pentry> join must overlap at least one previous entry
	at ghidra.program.model.lang.ParamEntry.resolveJoin(ParamEntry.java:384)
	at ghidra.program.model.lang.ParamEntry.restoreXml(ParamEntry.java:586)
	at ghidra.program.model.lang.ParamListStandard.parsePentry(ParamListStandard.java:244)
	at ghidra.program.model.lang.ParamListStandard.restoreXml(ParamListStandard.java:317)
	at ghidra.program.model.lang.ParamListStandardOut.restoreXml(ParamListStandardOut.java:77)
	at ghidra.program.model.lang.PrototypeModel.restoreXml(PrototypeModel.java:638)
	at ghidra.program.model.lang.BasicCompilerSpec.addPrototypeModel(BasicCompilerSpec.java:1067)
	at ghidra.program.model.lang.BasicCompilerSpec.restoreXml(BasicCompilerSpec.java:619)
	at ghidra.program.model.lang.BasicCompilerSpec.initialize(BasicCompilerSpec.java:244)
	at ghidra.program.model.lang.BasicCompilerSpec.<init>(BasicCompilerSpec.java:131)
	... 12 more
